### PR TITLE
Fix avcodec compile errors

### DIFF
--- a/platform/common/mp3_libavcodec.c
+++ b/platform/common/mp3_libavcodec.c
@@ -16,6 +16,11 @@
 #include "../libpicofe/lprintf.h"
 #include "mp3.h"
 
+#if LIBAVCODEC_VERSION_MAJOR < 55
+#define AVCodecID CodecID
+#define AV_CODEC_ID_MP3 CODEC_ID_MP3
+#endif
+
 static AVCodecContext *ctx;
 
 /* avoid compile time linking to libavcodec due to huge list of it's deps..
@@ -94,7 +99,7 @@ int mp3dec_decode(FILE *f, int *file_pos, int file_len)
 int mp3dec_start(FILE *f, int fpos_start)
 {
 	void (*avcodec_register_all)(void);
-	AVCodec *(*avcodec_find_decoder)(enum CodecID id);
+	AVCodec *(*avcodec_find_decoder)(enum AVCodecID id);
 	AVCodecContext *(*avcodec_alloc_context)(void);
 	int (*avcodec_open)(AVCodecContext *avctx, AVCodec *codec);
 	void (*av_free)(void *ptr);
@@ -137,8 +142,7 @@ int mp3dec_start(FILE *f, int fpos_start)
 	//avcodec_init();
 	avcodec_register_all();
 
-	// AV_CODEC_ID_MP3 ?
-	codec = avcodec_find_decoder(CODEC_ID_MP3);
+	codec = avcodec_find_decoder(AV_CODEC_ID_MP3);
 	if (codec == NULL) {
 		lprintf("mp3dec: codec missing\n");
 		return -1;


### PR DESCRIPTION
```
gcc -Wall -ggdb -falign-functions=2 -I. -O2 -DNDEBUG -ffunction-sections -I/usr/include/SDL -D_GNU_SOURCE=1 -D_REENTRANT -Wno-unused-result -DEMU_F68K -D_USE_CZ80   -c -o platform/common/mp3_libavcodec.o platform/common/mp3_libavcodec.c
platform/common/mp3_libavcodec.c: In function ‘mp3dec_start’:
platform/common/mp3_libavcodec.c:97:40: warning: ‘enum CodecID’ declared inside parameter list
  AVCodec *(*avcodec_find_decoder)(enum CodecID id);
                                        ^
platform/common/mp3_libavcodec.c:97:40: warning: its scope is only this definition or declaration, which is probably not what you want
platform/common/mp3_libavcodec.c:141:31: error: ‘CODEC_ID_MP3’ undeclared (first use in this function)
  codec = avcodec_find_decoder(CODEC_ID_MP3);
                               ^
platform/common/mp3_libavcodec.c:141:31: note: each undeclared identifier is reported only once for each function it appears in
platform/common/mp3_libavcodec.c:141:31: error: type of formal parameter 1 is incomplete
<builtin>: recipe for target 'platform/common/mp3_libavcodec.o' failed
make: *** [platform/common/mp3_libavcodec.o] Error 1
```