### PR TITLE
Enabe JIT for linux arm platform(Rpi...)

### DIFF
--- a/platform/linux/emu.c
+++ b/platform/linux/emu.c
@@ -31,7 +31,9 @@ void pemu_validate_config(void)
 {
 	extern int PicoOpt;
 //	PicoOpt &= ~POPT_EXT_FM;
+#ifndef __arm__
 	PicoOpt &= ~POPT_EN_DRC;
+#endif
 }
 
 static void draw_cd_leds(void)


### PR DESCRIPTION
On Raspberry PI, JIT get disabled since it is disabled in linux.
I put this disabling under __arm__ switch usince quite some JIT code are put under it...
32X runs faster on Rpi with this modification...