### PR TITLE
Makefile: Only set -g for debug builds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 TARGET ?= PicoDrive
-CFLAGS += -Wall -g
+CFLAGS += -Wall
 CFLAGS += -I.
 ifndef DEBUG
 CFLAGS += -O3 -DNDEBUG
+else
+CFLAGS += -O0 -g
 endif
 
 # This is actually needed, bevieve me.


### PR DESCRIPTION
I think `-g` is only needed for debug builds. Also setting `-O0` is a little bit more explicit.