### PR TITLE
Makefile: Build with optimizations if DEBUG=0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 TARGET ?= PicoDrive
+DEBUG  = 0
 CFLAGS += -Wall -g
 CFLAGS += -I.
-ifndef DEBUG
+ifeq "$(DEBUG)" "0"
 CFLAGS += -O3 -DNDEBUG
 endif
 


### PR DESCRIPTION
This makes picodrive build with optimizations if `DEBUG=0`. Before it would build with optimizations only if `DEBUG` is unset.

So by default picodrive will build with optimizations, if `DEBUG=0` it will build with optimizations and if `DEBUG=anything` it will not build with optimizations.

The goal behind this is to make it possible to explicitly enable or disable debug builds inside a build script.