### PR TITLE
libretro: Allow setting GIT_VERSION.

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -26,7 +26,7 @@ CFLAGS ?=
 STATIC_LINKING:= 0
 TARGET_NAME := picodrive
 LIBM := -lm
-GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+GIT_VERSION ?= " $(shell git rev-parse --short HEAD || echo unknown)"
 ifneq ($(GIT_VERSION)," unknown")
 	CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
 endif

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -2,7 +2,7 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
-GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+GIT_VERSION ?= " $(shell git rev-parse --short HEAD || echo unknown)"
 ifneq ($(GIT_VERSION)," unknown")
 	LOCAL_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
 endif


### PR DESCRIPTION
This is a small nitpick and for builds when the `.git` directory is missing, but the commit hash is still known it will allow setting the `GIT_VERSION` correctly which will show up in the RetroArch menu. This is useful for distros and many other libretro cores have already made this change.