### PR TITLE
RS90 Support

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -405,6 +405,30 @@ else ifeq ($(platform), emscripten)
 	STATIC_LINKING = 1
 	DONT_COMPILE_IN_ZLIB = 1
 
+# RS90
+else ifeq ($(platform), rs90)
+	TARGET := $(TARGET_NAME)_libretro.so
+	CC = /opt/rs90-toolchain/usr/bin/mipsel-linux-gcc
+	AR = /opt/rs90-toolchain/usr/bin/mipsel-linux-ar
+	SHARED := -shared -nostdlib
+        fpic := -fPIC
+	LIBM :=
+	DONT_COMPILE_IN_ZLIB = 1
+	CFLAGS += -ffast-math -march=mips32 -mtune=mips32
+
+	# Are this 100% correct?
+	asm_memory = 0
+	asm_render = 0
+	asm_ym2612 = 0
+	asm_misc = 0
+	asm_cdpico = 0
+	asm_cdmemory = 0
+	asm_mix = 0
+	use_cyclone = 0
+	use_fame = 1
+	use_drz80 = 0
+	use_cz80 = 1
+
 # GCW0
 else ifeq ($(platform), gcw0)
 	TARGET := $(TARGET_NAME)_libretro.so


### PR DESCRIPTION
Adds support for the RS90. 

Compiled and loaded Phantasy Star for the SMS.

More information on the platform here: https://github.com/libretro/RetroArch/pull/12592