### PR TITLE
Fix -Werror=strict-prototypes

### DIFF
--- a/configure
+++ b/configure
@@ -265,7 +265,7 @@ check_libpng()
 {
   cat > $TMPC <<EOF
   #include <png.h>
-  void main(void) { png_init_io(0, 0); }
+  int main(void) { png_init_io(0, 0); }
 EOF
 #  compile_binary
   compile_object
@@ -276,7 +276,7 @@ check_oss()
   cat > $TMPC <<EOF
   #include <sys/soundcard.h>
   #include <sys/ioctl.h>
-  void main(void) { int a=0; ioctl(0, SNDCTL_DSP_SETFMT, &a); }
+  int main(void) { int a=0; ioctl(0, SNDCTL_DSP_SETFMT, &a); }
 EOF
   compile_binary
 }
@@ -285,7 +285,7 @@ check_alsa()
 {
   cat > $TMPC <<EOF
   #include <alsa/asoundlib.h>
-  void main(void) { snd_pcm_open(0, 0, 0, 0); }
+  int main(void) { snd_pcm_open(0, 0, 0, 0); }
 EOF
   compile_binary "$@"
 }
@@ -294,7 +294,7 @@ check_sdl()
 {
   cat > $TMPC <<EOF
   #include <SDL.h>
-  void main(void) { SDL_OpenAudio(0, 0); }
+  int main(void) { SDL_OpenAudio(0, 0); }
 EOF
   compile_binary "$@"
 }
@@ -303,7 +303,7 @@ check_libavcodec()
 {
   cat > $TMPC <<EOF
   #include <libavcodec/avcodec.h>
-  void main(void) { avcodec_decode_audio3(0, 0, 0, 0); }
+  int main(void) { avcodec_decode_audio3(0, 0, 0, 0); }
 EOF
   compile_object "$@"
 }

--- a/configure
+++ b/configure
@@ -265,7 +265,7 @@ check_libpng()
 {
   cat > $TMPC <<EOF
   #include <png.h>
-  void main() { png_init_io(0, 0); }
+  void main(void) { png_init_io(0, 0); }
 EOF
 #  compile_binary
   compile_object
@@ -276,7 +276,7 @@ check_oss()
   cat > $TMPC <<EOF
   #include <sys/soundcard.h>
   #include <sys/ioctl.h>
-  void main() { int a=0; ioctl(0, SNDCTL_DSP_SETFMT, &a); }
+  void main(void) { int a=0; ioctl(0, SNDCTL_DSP_SETFMT, &a); }
 EOF
   compile_binary
 }
@@ -285,7 +285,7 @@ check_alsa()
 {
   cat > $TMPC <<EOF
   #include <alsa/asoundlib.h>
-  void main() { snd_pcm_open(0, 0, 0, 0); }
+  void main(void) { snd_pcm_open(0, 0, 0, 0); }
 EOF
   compile_binary "$@"
 }
@@ -294,7 +294,7 @@ check_sdl()
 {
   cat > $TMPC <<EOF
   #include <SDL.h>
-  void main() { SDL_OpenAudio(0, 0); }
+  void main(void) { SDL_OpenAudio(0, 0); }
 EOF
   compile_binary "$@"
 }
@@ -303,7 +303,7 @@ check_libavcodec()
 {
   cat > $TMPC <<EOF
   #include <libavcodec/avcodec.h>
-  void main() { avcodec_decode_audio3(0, 0, 0, 0); }
+  void main(void) { avcodec_decode_audio3(0, 0, 0, 0); }
 EOF
   compile_object "$@"
 }
@@ -353,6 +353,7 @@ if [ "$need_sdl" = "yes" ]; then
 fi
 
 cat > $TMPC <<EOF
+#include <stdio.h>
 void test(void *f, void *d) { fread(d, 1, 1, f); }
 EOF
 if compile_object -Wno-unused-result; then

--- a/pico/draw2.c
+++ b/pico/draw2.c
@@ -26,8 +26,7 @@ static int HighCache2A[41*(TILE_ROWS+1)+1+1]; // caches for high layers
 static int HighCache2B[41*(TILE_ROWS+1)+1+1];
 
 unsigned short *PicoCramHigh=PicoMem.cram; // pointer to CRAM buff (0x40 shorts), converted to native device color (works only with 16bit for now)
-void (*PicoPrepareCram)()=0;            // prepares PicoCramHigh for renderer to use
-
+void (*PicoPrepareCram)(void)=0;           // prepares PicoCramHigh for renderer to use
 
 // stuff available in asm:
 #ifdef _ASM_DRAW_C

--- a/pico/pico.h
+++ b/pico/pico.h
@@ -213,7 +213,7 @@ void PicoDrawSetInternalBuf(void *dest, int line_increment);
 // draw2.c
 // stuff below is optional
 extern unsigned short *PicoCramHigh; // pointer to CRAM buff (0x40 shorts), converted to native device color (works only with 16bit for now)
-extern void (*PicoPrepareCram)();    // prepares PicoCramHigh for renderer to use
+extern void (*PicoPrepareCram)(void); // prepares PicoCramHigh for renderer to use
 
 // pico.c (32x)
 #ifndef NO_32X

--- a/pico/pico_int.h
+++ b/pico/pico_int.h
@@ -657,7 +657,7 @@ extern int DrawLineDestIncrement;
 
 // draw2.c
 void PicoDraw2Init(void);
-PICO_INTERNAL void PicoFrameFull();
+PICO_INTERNAL void PicoFrameFull(void);
 
 // mode4.c
 void PicoFrameStartMode4(void);


### PR DESCRIPTION
This will be required for upcoming gcc and clang versions.

Reference: https://archives.gentoo.org/gentoo-dev/message/dd9f2d3082b8b6f8dfbccb0639e6e240