### PR TITLE
Fix -Werror=strict-prototypes with clang

### DIFF
--- a/pico/draw2.c
+++ b/pico/draw2.c
@@ -607,7 +607,7 @@ static void DrawDisplayFull(void)
 }
 
 
-PICO_INTERNAL void PicoFrameFull()
+PICO_INTERNAL void PicoFrameFull(void)
 {
 	pprof_start(draw);
 


### PR DESCRIPTION
@notaz I failed to commit one in the previous commit.

Fixes: https://github.com/notaz/picodrive/commit/fa43b5862d9bf4797b1fd4febcde2841d83ab103